### PR TITLE
修复all_lan_devices获取

### DIFF
--- a/custom_components/ikuai/data_fetcher.py
+++ b/custom_components/ikuai/data_fetcher.py
@@ -451,7 +451,7 @@ class DataFetcher:
 
         if 401 in results: return 401
 
-        all_lan_devices = results[3]
+        all_lan_devices = results[4]
 
         if self._tracker_config:
             network_error = (all_lan_devices is None)


### PR DESCRIPTION
all_lan_devices = results[3]时返回值为None导致设备追踪全部显示离开。